### PR TITLE
feat: only keep 1 sg

### DIFF
--- a/cde-full-setup/README.md
+++ b/cde-full-setup/README.md
@@ -22,7 +22,6 @@ No requirements.
 |------|------|
 | [aws_key_pair.placeholder_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/key_pair) | resource |
 | [aws_launch_template.full_example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
-| [aws_security_group.cloud-developer-environments](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group_rule.allow_all_within_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.cloud-developer-environments_egress_all_ipv4](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 

--- a/cde-full-setup/launch-template.tf
+++ b/cde-full-setup/launch-template.tf
@@ -13,7 +13,7 @@ resource "aws_launch_template" "full_example" {
 
   network_interfaces {
     associate_public_ip_address = true
-    security_groups             = [aws_security_group.cloud-developer-environments.id]
+    security_groups             = [module.vpc.vpc_default_security_group_id]
     subnet_id                   = module.subnets.public_subnet_ids[0]
   }
 

--- a/cde-full-setup/network.tf
+++ b/cde-full-setup/network.tf
@@ -19,11 +19,7 @@ module "subnets" {
   public_subnets_enabled  = true
 }
 
-resource "aws_security_group" "cloud-developer-environments" {
-  name        = "cloud-developer-environments"
-  description = "cloud-developer-environments"
-  vpc_id      = module.vpc.vpc_id
-}
+
 
 
 resource "aws_security_group_rule" "cloud-developer-environments_egress_all_ipv4" {
@@ -32,14 +28,14 @@ resource "aws_security_group_rule" "cloud-developer-environments_egress_all_ipv4
   to_port           = 65535
   protocol          = "-1"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = aws_security_group.cloud-developer-environments.id
+  security_group_id = module.vpc.vpc_default_security_group_id
 }
 
 resource "aws_security_group_rule" "allow_all_within_group" {
-  security_group_id = aws_security_group.cloud-developer-environments.id
   type              = "ingress"
   from_port         = 22
   to_port           = 22
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = module.vpc.vpc_default_security_group_id
 }


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Migrated the configuration to use the default VPC security group instead of a custom security group.
- Removed the custom security group resource definition.
- Updated security group rules to reference the default VPC security group.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>launch-template.tf</strong><dd><code>Use default VPC security group in launch template</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cde-full-setup/launch-template.tf

<li>Updated security group reference to use the default VPC security <br>group.<br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-aws-cloud-developer-environments/pull/6/files#diff-f98d96936d882f7018165d68195d0d9b865a3b3ddbf8d9f39a65e28f3c7105b9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>network.tf</strong><dd><code>Migrate to default VPC security group for network rules</code>&nbsp; &nbsp; </dd></summary>
<hr>

cde-full-setup/network.tf

<li>Removed custom security group resource.<br> <li> Updated security group rules to use the default VPC security group.<br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-aws-cloud-developer-environments/pull/6/files#diff-e460adb3d4dcd03b038316de754c06f73f21238ffed4476b6dfac2f5d326791d">+3/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information