### PR TITLE
feat: adding iam-user-slackbot.tf

### DIFF
--- a/cde-iam-setup/README.md
+++ b/cde-iam-setup/README.md
@@ -24,7 +24,10 @@ No modules.
 | [aws_iam_group_policy_attachment.password-mgmt](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_group_policy_attachment) | resource |
 | [aws_iam_policy.ec2_instance_connect](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.password-mgmt](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.slackbot](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_user.slackbot](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_iam_user.users](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
+| [aws_iam_user_policy_attachment.slackbot](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
 
 ## Inputs
 

--- a/cde-iam-setup/iam-user-slackbot.tf
+++ b/cde-iam-setup/iam-user-slackbot.tf
@@ -1,0 +1,23 @@
+resource "aws_iam_user" "slackbot" {
+  name = "slackbot"
+}
+resource "aws_iam_policy" "slackbot" {
+  name        = "slackbot"
+  description = "Used devBot in GlueOps slack"
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "ec2:*",
+        ],
+        Resource = "*"
+      },
+    ]
+  })
+}
+resource "aws_iam_user_policy_attachment" "slackbot" {
+  user       = aws_iam_user.slackbot.name
+  policy_arn = aws_iam_policy.slackbot.arn
+}


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Introduced a new IAM user `slackbot` for integration with GlueOps Slack.
- Defined an IAM policy granting EC2 permissions and attached it to the `slackbot` user.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>iam-user-slackbot.tf</strong><dd><code>Add IAM user and policy for Slackbot integration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cde-iam-setup/iam-user-slackbot.tf

<li>Added a new IAM user named <code>slackbot</code>.<br> <li> Created an IAM policy named <code>slackbot</code> with permissions for EC2 actions.<br> <li> Attached the policy to the <code>slackbot</code> user.<br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-aws-cloud-developer-environments/pull/7/files#diff-9b031cefa18aaac3d63ec70f1de6687b670a8580f57929bade2eca2082ed2af4">+23/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information